### PR TITLE
Bump strict_max_version to support Thunderbird 142.*

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
     "gecko": {
       "id": "togglelinewrap@kiszka.org",
       "strict_min_version": "128.0",
-      "strict_max_version": "140.*"
+      "strict_max_version": "142.*"
     }
   },
   "name": "Toggle Line Wrap",


### PR DESCRIPTION
Tested it locally with Mozilla Thunderbird 142.0 on Arch Linux and extension seems to be working fine.

Also bumped version number with a patch release.